### PR TITLE
Added UserData to droplet request

### DIFF
--- a/DigitalOcean.API/Models/Requests/Droplet.cs
+++ b/DigitalOcean.API/Models/Requests/Droplet.cs
@@ -56,5 +56,11 @@ namespace DigitalOcean.API.Models.Requests {
         /// </summary>
         [JsonProperty("private_networking")]
         public bool PrivateNetworking { get; set; }
+        
+        /// <summary>
+        /// A string containing a YAML formatted Cloud-Init script
+        /// </summary>
+        [JsonProperty("user_data")]
+        public string UserData { get; set; }
     }
 }


### PR DESCRIPTION
Added UserData, which corresponds to the user_data JSON property of the digital ocean API. I've tested it by creating a new droplet and using the write_files directive, and it worked.