### PR TITLE
Add TTL field for domain records

### DIFF
--- a/DigitalOcean.API/Models/Requests/DomainRecord.cs
+++ b/DigitalOcean.API/Models/Requests/DomainRecord.cs
@@ -33,6 +33,12 @@ namespace DigitalOcean.API.Models.Requests {
         public int? Port { get; set; }
 
         /// <summary>
+        /// Time to live for the record, in seconds. If not set, the default value is 1800.
+        /// </summary>
+        [JsonProperty("ttl")]
+        public int? TTL { get; set; }
+
+        /// <summary>
         /// The weight of records with the same priority (for SRV records only. null otherwise).
         /// </summary>
         [JsonProperty("weight")]

--- a/DigitalOcean.API/Models/Responses/DomainRecord.cs
+++ b/DigitalOcean.API/Models/Responses/DomainRecord.cs
@@ -31,6 +31,11 @@
         public int? Port { get; set; }
 
         /// <summary>
+        /// Time to live for the record, in seconds. If not set, the default value is 1800.
+        /// </summary>
+        public int? TTL { get; set; }
+
+        /// <summary>
         /// The weight of records with the same priority (for SRV records only. null otherwise).
         /// </summary>
         public int? Weight { get; set; }


### PR DESCRIPTION
I've been playing with this amazing library for a while, and I noticed it misses the TTL property for domain records, so I've added it to the models.

Thanks!